### PR TITLE
Scheduler run now returns (success, result) tuple.

### DIFF
--- a/src/ppytty/kernel/state.py
+++ b/src/ppytty/kernel/state.py
@@ -15,6 +15,12 @@ tasks = types.SimpleNamespace(
     # The task given to the scheduler, to be run.
     top_task = None,
 
+    # True if top_task completed, False otherwise (exception or interrupted).
+    top_task_success = None,
+
+    # Exception if top_task_success is False, else whatever top_task returned.
+    top_task_result = None,
+
     # Runnable tasks queue.
     runnable = collections.deque(),
 
@@ -87,6 +93,8 @@ state = types.SimpleNamespace(
 def reset():
 
     tasks.top_task = None
+    tasks.top_task_success = None
+    tasks.top_task_result = None
     tasks.runnable = collections.deque()
     tasks.terminated = []
     tasks.parent = {}

--- a/src/ppytty/lib/tasks/parallel.py
+++ b/src/ppytty/lib/tasks/parallel.py
@@ -22,20 +22,20 @@ class Parallel(task.Task):
     def run(self):
 
         running_tasks = []
-        return_values = {}
+        results = {}
 
         for task in self._tasks:
             yield ('task-spawn', task)
             running_tasks.append(task)
         while len(running_tasks) > self._stop_last:
-            task, return_value = yield ('task-wait',)
-            return_values[task] = return_value
+            task, success, return_value = yield ('task-wait',)
+            results[task] = (success, return_value)
             running_tasks.remove(task)
         for task in running_tasks:
             yield ('task-destroy', task)
-            _, _ = yield ('task-wait',)
+            _ = yield ('task-wait',)
 
-        return return_values
+        return results
 
 
     def reset(self):

--- a/src/ppytty/lib/tasks/serial.py
+++ b/src/ppytty/lib/tasks/serial.py
@@ -44,10 +44,10 @@ class Serial(task.Task):
                 task = self._monitor_factory(task, index, index_max)
 
             yield ('task-spawn', task)
-            _, nav_hint = yield ('task-wait',)
+            _, success, nav_hint = yield ('task-wait',)
 
             action = self._default_nav
-            if self._take_nav_hint and nav_hint in self._ACTIONS:
+            if self._take_nav_hint and success and nav_hint in self._ACTIONS:
                 action = nav_hint
 
             last_run_index = index

--- a/src/ppytty/lib/tasks/utils.py
+++ b/src/ppytty/lib/tasks/utils.py
@@ -62,7 +62,7 @@ class Loop(task.Task):
         while times_to_go is None or times_to_go:
             self._task.reset()
             yield ('task-spawn', self._task)
-            _, _ = yield ('task-wait',)
+            _ = yield ('task-wait',)
             if times_to_go is not None:
                 times_to_go -= 1
 
@@ -86,7 +86,7 @@ class MasterSlave(task.Task):
         yield ('task-spawn', self._master)
         yield ('task-spawn', self._slave)
 
-        completed_first, value = yield('task-wait',)
+        completed_first, _success, value = yield('task-wait',)
         if completed_first is self._master:
             yield ('task-destroy', self._slave)
             return_value = value
@@ -96,7 +96,7 @@ class MasterSlave(task.Task):
         else:
             self._log.error('unexpected first completed: %r', completed_first)
 
-        completed_second, value = yield ('task-wait',)
+        completed_second, _success, value = yield ('task-wait',)
         if completed_second is not expected_second:
             self._log.error('unexpected second completed: %r', completed_second)
         if completed_second is self._master:
@@ -128,14 +128,14 @@ class RunForAtLeast(task.Task):
         yield ('task-spawn', timeout_task)
         yield ('task-spawn', self._task)
 
-        completed_first, value = yield ('task-wait',)
+        completed_first, _success, value = yield ('task-wait',)
         if completed_first is self._task:
             return_value = value if self._return_early is TASK else self._return_early
             expected_second = timeout_task
         elif completed_first is timeout_task:
             expected_second = self._task
 
-        completed_second, value = yield ('task-wait',)
+        completed_second, _success, value = yield ('task-wait',)
         if completed_second is not expected_second:
             self._log.error('unexpected second completed: %r', completed_second)
         if completed_second is self._task:
@@ -163,7 +163,7 @@ class RunForAtMost(task.Task):
         yield ('task-spawn', timeout_task)
         yield ('task-spawn', self._task)
 
-        completed_first, value = yield ('task-wait',)
+        completed_first, _success, value = yield ('task-wait',)
         if completed_first is self._task:
             stop_second = timeout_task
             return_value = value if self._return_early is TASK else self._return_early
@@ -171,7 +171,7 @@ class RunForAtMost(task.Task):
             stop_second = self._task
 
         yield ('task-destroy', stop_second)
-        completed_second, value = yield ('task-wait',)
+        completed_second, _success, value = yield ('task-wait',)
         if completed_second is not stop_second:
             self._log.error('unexpected second completed: %r', completed_second)
         if completed_second is self._task:

--- a/tests/kernel/tasks.py
+++ b/tests/kernel/tasks.py
@@ -1,0 +1,31 @@
+# ----------------------------------------------------------------------------
+# ppytty
+# ----------------------------------------------------------------------------
+# Copyright (c) Tiago Montes.
+# See LICENSE for details.
+# ----------------------------------------------------------------------------
+
+
+
+def sleep_zero():
+
+    yield ('sleep', 0)
+
+
+
+def spawn_sleep_zero_gen_function():
+
+    generator_function = sleep_zero
+    yield ('task-spawn', generator_function)
+    yield ('task-wait',)
+
+
+
+def spawn_sleep_zero_gen_object():
+
+    generator_object = sleep_zero()
+    yield ('task-spawn', generator_object)
+    yield ('task-wait',)
+
+
+# ----------------------------------------------------------------------------

--- a/tests/kernel/tasks.py
+++ b/tests/kernel/tasks.py
@@ -28,4 +28,11 @@ def spawn_sleep_zero_gen_object():
     yield ('task-wait',)
 
 
+
+def sleep_zero_return_42_idiv_arg(arg):
+
+    yield ('sleep', 0)
+    return 42 // arg
+
+
 # ----------------------------------------------------------------------------

--- a/tests/kernel/test_python_api.py
+++ b/tests/kernel/test_python_api.py
@@ -51,4 +51,21 @@ class TestRun(unittest.TestCase):
         run(generator_object)
 
 
+
+class TestReturns(unittest.TestCase):
+
+    def test_task_return(self):
+
+        success, result = run(tasks.sleep_zero_return_42_idiv_arg(42))
+        self.assertTrue(success)
+        self.assertEqual(result, 1)
+
+
+    def test_task_exception(self):
+
+        success, result = run(tasks.sleep_zero_return_42_idiv_arg(0))
+        self.assertFalse(success)
+        self.assertIsInstance(result, ZeroDivisionError)
+
+
 # ----------------------------------------------------------------------------

--- a/tests/kernel/test_python_api.py
+++ b/tests/kernel/test_python_api.py
@@ -9,27 +9,7 @@ import unittest
 
 from ppytty import run
 
-
-
-def _sleep_zero_task():
-
-    yield ('sleep', 0)
-
-
-
-def _spawn_sleep_zero_task_via_function():
-
-    generator_function = _sleep_zero_task
-    yield ('task-spawn', generator_function)
-    yield ('task-wait',)
-
-
-
-def _spawn_sleep_zero_task_via_object():
-
-    generator_object = _sleep_zero_task()
-    yield ('task-spawn', generator_object)
-    yield ('task-wait',)
+from . import tasks
 
 
 
@@ -37,38 +17,38 @@ class TestRun(unittest.TestCase):
 
     def test_gen_function(self):
 
-        generator_function = _sleep_zero_task
+        generator_function = tasks.sleep_zero
         run(generator_function)
 
 
     def test_gen_object(self):
 
-        generator_object = _sleep_zero_task()
+        generator_object = tasks.sleep_zero()
         run(generator_object)
 
 
     def test_gen_function_spawn_gen_function(self):
 
-        generator_function = _spawn_sleep_zero_task_via_function
+        generator_function = tasks.spawn_sleep_zero_gen_function
         run(generator_function)
 
 
     def test_gen_function_spawn_gen_object(self):
 
-        generator_function = _spawn_sleep_zero_task_via_object
+        generator_function = tasks.spawn_sleep_zero_gen_object
         run(generator_function)
 
 
     def test_gen_object_spawn_gen_function(self):
 
-        generator_function = _spawn_sleep_zero_task_via_function()
-        run(generator_function)
+        generator_object = tasks.spawn_sleep_zero_gen_function()
+        run(generator_object)
 
 
     def test_gen_object_spawn_gen_object(self):
 
-        generator_function = _spawn_sleep_zero_task_via_object()
-        run(generator_function)
+        generator_object = tasks.spawn_sleep_zero_gen_object()
+        run(generator_object)
 
 
 # ----------------------------------------------------------------------------

--- a/tests/kernel/test_state.py
+++ b/tests/kernel/test_state.py
@@ -68,6 +68,8 @@ def _change_dict(object, attr_name):
 STATE_OBJECTS = {
     'tasks': {
         'top_task': (_assert_is_none, _change_scalar),
+        'top_task_success': (_assert_is_none, _change_scalar),
+        'top_task_result': (_assert_is_none, _change_scalar),
         'runnable': (_assert_empty_list, _change_list),
         'terminated': (_assert_empty_list, _change_list),
         'parent': (_assert_empty_dict, _change_dict),


### PR DESCRIPTION
Details:
* `success` is `True` if `top_task` runs to completion, `False` if it raises an exception or is interrupted, `None` otherwise (should not happen).
* `result` is the return value of `top_task` if `success` is `True` or the `Exception`, otherwise.

More:
* The `wait-task` trap now returns a three-tuple: (task, success, result).
