### PR TITLE
Kernel test cases generating output now have it "captured" via mock.patch.

### DIFF
--- a/tests/kernel/io_bypass.py
+++ b/tests/kernel/io_bypass.py
@@ -1,0 +1,47 @@
+# ----------------------------------------------------------------------------
+# ppytty
+# ----------------------------------------------------------------------------
+# Copyright (c) Tiago Montes.
+# See LICENSE for details.
+# ----------------------------------------------------------------------------
+
+
+from unittest import TestCase, mock
+
+
+
+class NoOutputTestCase(TestCase):
+
+    _PATCHES = [
+        # Patch ppytty.kernel.hw output related attributes.
+        ('ppytty.kernel.hw.os_write', mock.DEFAULT),
+        ('ppytty.kernel.hw.termios_tcgetattr', mock.DEFAULT),
+        ('ppytty.kernel.hw.termios_tcsetattr', mock.DEFAULT),
+        ('ppytty.kernel.hw.sys_stdout', mock.DEFAULT),
+
+        # Patch blessings usage of ioctl to return an 80x25 terminal size.
+        # (it would otherwise fail when given the above mocked stdout)
+        ('blessings.ioctl', b'\x19\x00P\x00\x00\x00\x00\x00'),
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+
+        cls._mock_patches = [
+            mock.patch(what, return_value=rv)
+            for what, rv in cls._PATCHES
+        ]
+
+        for patch in cls._mock_patches:
+            patch.start()
+
+
+
+    @classmethod
+    def tearDownClass(cls):
+
+        for patch in cls._mock_patches:
+            patch.stop()
+
+
+# ----------------------------------------------------------------------------

--- a/tests/kernel/test_python_api.py
+++ b/tests/kernel/test_python_api.py
@@ -9,11 +9,12 @@ import unittest
 
 from ppytty import run
 
+from . import io_bypass
 from . import tasks
 
 
 
-class TestRun(unittest.TestCase):
+class TestRun(io_bypass.NoOutputTestCase):
 
     def test_gen_function(self):
 
@@ -28,7 +29,7 @@ class TestRun(unittest.TestCase):
 
 
 
-class TestReturns(unittest.TestCase):
+class TestReturns(io_bypass.NoOutputTestCase):
 
     def test_task_return(self):
 

--- a/tests/kernel/test_tasks.py
+++ b/tests/kernel/test_tasks.py
@@ -9,11 +9,12 @@ import unittest
 
 from ppytty import run
 
+from . import io_bypass
 from . import tasks
 
 
 
-class TestSpawn(unittest.TestCase):
+class TestSpawn(io_bypass.NoOutputTestCase):
 
     def test_spawn_gen_function(self):
 
@@ -30,7 +31,7 @@ class TestSpawn(unittest.TestCase):
 
 
 
-class TestWait(unittest.TestCase):
+class TestWait(io_bypass.NoOutputTestCase):
 
     def test_wait_child_success(self):
 


### PR DESCRIPTION
Contributing towards #9.