### PR TITLE
Top task message-send to parent throws TrapException.

### DIFF
--- a/src/ppytty/kernel/trap_handlers.py
+++ b/src/ppytty/kernel/trap_handlers.py
@@ -200,10 +200,12 @@ def task_destroy(task, user_child_task, keep_running=True):
 def message_send(task, to_user_task, message):
 
     if to_user_task is None:
-        to_task = state.parent_task.get(task)
-        if to_task is None:
-            log.warning('%r no parent task for message send', task)
-            # TODO: throw an exception into the calling task?
+        try:
+            to_task = state.parent_task[task]
+        except KeyError:
+            exc = exceptions.TrapException('no parent task for message send')
+            common.trap_will_throw(task, exc)
+            state.runnable_tasks.append(task)
             return
     else:
         to_task = state.kernel_space_tasks[to_user_task]

--- a/tests/kernel/test_task_api_msgs.py
+++ b/tests/kernel/test_task_api_msgs.py
@@ -5,7 +5,7 @@
 # See LICENSE for details.
 # ----------------------------------------------------------------------------
 
-from ppytty import run
+from ppytty import run, TrapException
 
 from . import io_bypass
 from . import log_helper
@@ -186,5 +186,20 @@ class TestSenderTaskIsChildTask(io_bypass.NoOutputTestCase):
         self.assertTrue(success)
         self._assert_parent_result(child_gen_object, result)
 
+
+
+class TestTrapExceptions(io_bypass.NoOutputTestCase):
+
+    def test_top_task_message_parent_fails(self):
+
+        def top_task():
+            yield ('message-send', None, 'goes-nowhere')
+
+        success, result = run(top_task)
+
+        self.assertFalse(success)
+        self.assertIsInstance(result, TrapException)
+        self.assertGreaterEqual(len(result.args), 1)
+        self.assertIn('parent', result.args[0])
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
One more #9 contribution.