### PR TITLE
Test task-destroy trap on a running task + sleep zero keeps task running.

### DIFF
--- a/src/ppytty/kernel/trap_handlers.py
+++ b/src/ppytty/kernel/trap_handlers.py
@@ -101,6 +101,10 @@ def window_render(task, window, full=False):
 
 def sleep(task, seconds):
 
+    if seconds <= 0:
+        state.runnable_tasks.append(task)
+        return
+
     wake_at = state.now + seconds
     state.tasks_waiting_time.append(task)
     heapq.heappush(state.tasks_waiting_time_hq, (wake_at, id(task), task))


### PR DESCRIPTION
One more contribution to #9.