### PR TITLE
Updated kernel trap API: now coroutine based.

### DIFF
--- a/src/ppytty/__init__.py
+++ b/src/ppytty/__init__.py
@@ -31,6 +31,9 @@ __author__ = 'Tiago Montes'
 __email__ = 'tiago.montes@gmail.com'
 
 
+
+from . kernel import run
+
 from . lib import (
     Task,
     Parallel, Serial,
@@ -41,11 +44,10 @@ from . lib import (
     Label,
     Widget,
 )
-from . kernel import (
-    run, TrapException, TrapDestroyed, TrapDoesNotExist, TrapArgCountWrong,
-)
+
 
 __all__ = [
+    'run',
     'OuterSequenceKeyboard',
     'OuterSequenceTimed',
     'Slide',
@@ -59,11 +61,6 @@ __all__ = [
     'DelayReturn',
     'KeyboardAction',
     'Loop',
-    'run',
-    'TrapException',
-    'TrapDestroyed',
-    'TrapDoesNotExist',
-    'TrapArgCountWrong',
 ]
 
 # ----------------------------------------------------------------------------

--- a/src/ppytty/kernel/__init__.py
+++ b/src/ppytty/kernel/__init__.py
@@ -6,8 +6,7 @@
 # ----------------------------------------------------------------------------
 
 from . scheduler import run
-from . exceptions import (
-    TrapException, TrapDestroyed, TrapDoesNotExist, TrapArgCountWrong,
-)
+from . import api
+from . import exceptions
 
 # ----------------------------------------------------------------------------

--- a/src/ppytty/kernel/api.py
+++ b/src/ppytty/kernel/api.py
@@ -1,0 +1,161 @@
+# ----------------------------------------------------------------------------
+# ppytty
+# ----------------------------------------------------------------------------
+# Copyright (c) Tiago Montes.
+# See LICENSE for details.
+# ----------------------------------------------------------------------------
+
+"""
+Kernel Trap API
+
+Running tasks use these to interact with the kernel.
+"""
+
+import types
+
+
+
+@types.coroutine
+def direct_clear():
+    """
+    Clear the output TTY, bypassing kernel terminal/window handling.
+    """
+    yield 'direct-clear',
+
+
+
+@types.coroutine
+def direct_print(text, x=None, y=None, save_location=False):
+    """
+    Print to the output TTY, bypassing kernel terminal/window handling.
+    """
+    yield 'direct-print', text, x, y, save_location
+
+
+
+@types.coroutine
+def window_create(left, top, width, height, background=None):
+    """
+    Creates a kernel managed window.
+    """
+    return (yield 'window-create', left, top, width, height, background)
+
+
+
+
+@types.coroutine
+def window_destroy(window):
+    """
+    Destroys `window`. If it has been rendered, the output terminal will be
+    updated to reflect its destruction.
+
+    Raises TrapException if `window` is not a caller task created window.
+    """
+    yield 'window-destroy', window
+
+
+
+@types.coroutine
+def window_render(window, full=False):
+    """
+    Renders `window` onto the output terminal.
+    If `full` is True, the whole window contents is rendered; otherwise, only
+    the lines that changed since the previous render will be rendered.
+    """
+    yield 'window-render', window, full
+
+
+
+@types.coroutine
+def sleep(seconds):
+    """
+    Sleep caller for `seconds` seconds.
+    """
+    yield 'sleep', seconds
+
+
+
+@types.coroutine
+def key_read(priority=0):
+    """
+    Blocks caller task, waiting for the kernel managed TTY input.
+    Returns a single byte value.
+
+    Concurrent reads are served on a `priority` basis: outstanding reads with
+    lower numeric `priority` are served first. High priority readers can pass
+    read byte values to lower priority ones via the `key_unread` trap.
+    """
+    return (yield 'read-key', priority)
+
+
+
+@types.coroutine
+def key_unread(key_byte_value):
+    """
+    See `key_read`.
+    """
+    yield 'put-key', key_byte_value
+
+
+
+@types.coroutine
+def task_spawn(task):
+    """
+    Spawns a new task as a child of the caller.
+    """
+    yield 'task-spawn', task
+
+
+
+@types.coroutine
+def task_wait():
+    """
+    Waits for child task completion.
+    Returns (completed_task, success, result) tuple.
+    """
+    return (yield 'task-wait',)
+
+
+
+@types.coroutine
+def task_destroy(task):
+    """
+    Destroys `task` and all its children regardless of their state.
+    Raises a TrapException if the given `task` is not a child of the caller.
+
+    The destroyed `task` must still be waited for with a `task_wait` call:
+    the `success` will be `False` and `result` will a TrapDestroyed instance.
+    """
+    yield 'task-destroy', task
+
+
+
+@types.coroutine
+def message_send(task, message):
+    """
+    Sends `message` to `task`. When `task` is None, sends `message to parent.
+    """
+    yield 'message-send', task, message
+
+
+
+@types.coroutine
+def message_wait():
+    """
+    Waits for a message to be received.
+    Returns (sender_task, message) tuple.
+    """
+    return (yield 'message-wait',)
+
+
+
+@types.coroutine
+def state_dump(tag=''):
+    """
+    Dumps the kernel state to the log, tagged with the optional `tag`.
+    """
+    yield 'state-dump', tag
+
+
+
+# ----------------------------------------------------------------------------

--- a/tests/kernel/tasks.py
+++ b/tests/kernel/tasks.py
@@ -6,26 +6,29 @@
 # ----------------------------------------------------------------------------
 
 
-
-def sleep_zero():
-
-    yield ('sleep', 0)
+from ppytty.kernel import api
 
 
 
-def spawn_wait(task, sleep_before_wait=False):
+async def sleep_zero():
 
-    yield ('task-spawn', task)
+    await api.sleep(0)
+
+
+
+async def spawn_wait(task, sleep_before_wait=False):
+
+    await api.task_spawn(task)
     if sleep_before_wait:
-        yield ('sleep', 0)
-    completed_task, success, result = yield ('task-wait',)
+        await api.sleep(0)
+    completed_task, success, result = await api.task_wait()
     return completed_task, success, result
 
 
 
-def sleep_zero_return_42_idiv_arg(arg):
+async def sleep_zero_return_42_idiv_arg(arg):
 
-    yield ('sleep', 0)
+    await api.sleep(0)
     return 42 // arg
 
 

--- a/tests/kernel/test_task_api_bad.py
+++ b/tests/kernel/test_task_api_bad.py
@@ -5,7 +5,8 @@
 # See LICENSE for details.
 # ----------------------------------------------------------------------------
 
-from ppytty import run, TrapDoesNotExist, TrapArgCountWrong
+from ppytty.kernel import run
+from ppytty.kernel.exceptions import TrapDoesNotExist, TrapArgCountWrong
 
 from . import helper_io
 

--- a/tests/kernel/test_task_api_bad.py
+++ b/tests/kernel/test_task_api_bad.py
@@ -34,7 +34,7 @@ class Test(helper_io.NoOutputTestCase):
             try:
                 yield ('this-trap-does-not-exist',)
             except TrapDoesNotExist:
-                yield ('sleep', 0)
+                pass
 
         success, result = run(task)
         self.assertTrue(success)
@@ -61,7 +61,7 @@ class Test(helper_io.NoOutputTestCase):
             try:
                 yield ('sleep', 1, 2, 3)
             except TrapArgCountWrong:
-                yield ('sleep', 0)
+                pass
 
         success, result = run(task)
         self.assertTrue(success)

--- a/tests/kernel/test_task_api_dout.py
+++ b/tests/kernel/test_task_api_dout.py
@@ -5,7 +5,7 @@
 # See LICENSE for details.
 # ----------------------------------------------------------------------------
 
-from ppytty import run
+from ppytty.kernel import run
 
 from . import helper_io
 

--- a/tests/kernel/test_task_api_dout.py
+++ b/tests/kernel/test_task_api_dout.py
@@ -5,7 +5,7 @@
 # See LICENSE for details.
 # ----------------------------------------------------------------------------
 
-from ppytty.kernel import run
+from ppytty.kernel import run, api
 
 from . import helper_io
 
@@ -21,10 +21,10 @@ class Test(helper_io.NoOutputTestCase):
 
     def _drive_output_test(self, trap, prefixes, payload, suffixes):
 
-        def task():
+        async def task():
             # Discard any previously emmited output.
             self.reset_os_written_bytes()
-            yield trap
+            await trap
             # Return written bytes now. Motive: on stopping, run() outputs
             # terminal "cleanup" escapes which end up as written bytes.
             return self.get_os_written_bytes()
@@ -37,7 +37,7 @@ class Test(helper_io.NoOutputTestCase):
 
     def test_direct_print(self):
 
-        trap = ('direct-print', 'this is the output message')
+        trap = api.direct_print('this is the output message')
 
         out_prefixes = []
         out_suffixes = []
@@ -48,7 +48,7 @@ class Test(helper_io.NoOutputTestCase):
 
     def test_direct_print_with_position(self):
 
-        trap = ('direct-print', 'this is the output message', 4, 2)
+        trap = api.direct_print('this is the output message', 4, 2)
 
         # Expect curses.tigetstr('cup'), then passed to curses.tparm(..., 2, 4)
         # to position the cusor; tparm args are (row, col), ours are (col, row).
@@ -62,7 +62,7 @@ class Test(helper_io.NoOutputTestCase):
 
     def test_direct_print_with_position_and_cursor_restore(self):
 
-        trap = ('direct-print', 'this is the output message', 4, 2, True)
+        trap = api.direct_print('this is the output message', 4, 2, True)
 
         # Expect curses.tigetstr('sc') prefix to save the cursor position,
         # followed by the same cursor positioning as in the previous test.
@@ -80,7 +80,7 @@ class Test(helper_io.NoOutputTestCase):
 
     def test_direct_clear(self):
 
-        trap = ('direct-clear', )
+        trap = api.direct_clear()
 
         out_prefixes = []
         out_suffixes = []

--- a/tests/kernel/test_task_api_key.py
+++ b/tests/kernel/test_task_api_key.py
@@ -5,7 +5,7 @@
 # See LICENSE for details.
 # ----------------------------------------------------------------------------
 
-from ppytty.kernel import run, scheduler
+from ppytty.kernel import run, api, scheduler
 
 from . import helper_io
 from . import helper_log
@@ -16,8 +16,8 @@ class Test(helper_io.NoOutputAutoTimeControlledInputTestCase):
 
     def test_read_key(self):
 
-        def task():
-            result = yield ('read-key', 100)
+        async def task():
+            result = await api.key_read(priority=100)
             return result
 
         self.input_control.feed_data(b'x')
@@ -30,15 +30,15 @@ class Test(helper_io.NoOutputAutoTimeControlledInputTestCase):
 
     def test_blocking_read_key(self):
 
-        def child():
-            byte_key = yield ('read-key', 100)
+        async def child():
+            byte_key = await api.key_read(priority=100)
             return byte_key
 
-        def parent(child_task):
-            yield ('task-spawn', child_task)
-            yield ('sleep', 1)
+        async def parent(child_task):
+            await api.task_spawn(child_task)
+            await api.sleep(1)
             self.input_control.feed_data(b'k')
-            task_wait_result = yield ('task-wait',)
+            task_wait_result = await api.task_wait()
             return task_wait_result
 
         child_task = child()
@@ -54,21 +54,21 @@ class Test(helper_io.NoOutputAutoTimeControlledInputTestCase):
 
     def test_read_key_priority(self):
 
-        def child(read_key_priority):
-            byte_key = yield ('read-key', read_key_priority)
+        async def child(read_key_priority):
+            byte_key = await api.key_read(priority=read_key_priority)
             return byte_key
 
-        def parent(hi_pri_reader, lo_pri_reader):
+        async def parent(hi_pri_reader, lo_pri_reader):
             all_tasks = {hi_pri_reader, lo_pri_reader}
-            yield ('task-spawn', lo_pri_reader)
-            yield ('task-spawn', hi_pri_reader)
-            yield ('sleep', 1)
+            await api.task_spawn(lo_pri_reader)
+            await api.task_spawn(hi_pri_reader)
+            await api.sleep(1)
             self.input_control.feed_data(b'i')
-            completed_task, child_success, child_result = yield ('task-wait',)
+            completed_task, child_success, child_result = await api.task_wait()
             all_tasks.remove(completed_task)
             other_task = all_tasks.pop()
-            yield ('task-destroy', other_task)
-            destroyed_task, _, _ = yield ('task-wait',)
+            await api.task_destroy(other_task)
+            destroyed_task, _, _ = await api.task_wait()
             return completed_task, child_success, child_result, destroyed_task
 
         hi_pri_reader = child(100)
@@ -87,26 +87,26 @@ class Test(helper_io.NoOutputAutoTimeControlledInputTestCase):
 
     def test_put_key(self):
 
-        def hi_pri_child():
-            byte_key = yield ('read-key', 100)
-            yield ('put-key', byte_key)
-            yield ('sleep', 42)
+        async def hi_pri_child():
+            byte_key = await api.key_read(priority=100)
+            await api.key_unread(byte_key)
+            await api.sleep(42)
 
-        def lo_pri_child():
-            byte_key = yield ('read-key', 1000)
+        async def lo_pri_child():
+            byte_key = await api.key_read(priority=1000)
             return byte_key
 
-        def parent(hi_pri_reader, lo_pri_reader):
+        async def parent(hi_pri_reader, lo_pri_reader):
             all_tasks = {hi_pri_reader, lo_pri_reader}
-            yield ('task-spawn', lo_pri_reader)
-            yield ('task-spawn', hi_pri_reader)
-            yield ('sleep', 1)
+            await api.task_spawn(lo_pri_reader)
+            await api.task_spawn(hi_pri_reader)
+            await api.sleep(1)
             self.input_control.feed_data(b't')
-            completed_task, child_success, child_result = yield ('task-wait',)
+            completed_task, child_success, child_result = await api.task_wait()
             all_tasks.remove(completed_task)
             other_task = all_tasks.pop()
-            yield ('task-destroy', other_task)
-            destroyed_task, _, _ = yield ('task-wait',)
+            await api.task_destroy(other_task)
+            destroyed_task, _, _ = await api.task_wait()
             return completed_task, child_success, child_result, destroyed_task
 
         success, result = run(parent(hi_pri_child, lo_pri_child))
@@ -121,9 +121,9 @@ class Test(helper_io.NoOutputAutoTimeControlledInputTestCase):
 
     def test_kernel_run_stops_with_double_q_input(self):
 
-        def task():
+        async def task():
             while True:
-                yield ('sleep', 42)
+                await api.sleep(42)
 
         self.input_control.feed_data(b'qq')
 
@@ -135,8 +135,8 @@ class Test(helper_io.NoOutputAutoTimeControlledInputTestCase):
 
     def test_kernel_run_does_not_stop_with_q_and_something_else(self):
 
-        def task():
-            yield ('sleep', 42)
+        async def task():
+            await api.sleep(42)
             return 'confirming-regular-completion'
 
         self.input_control.feed_data(b'qx')
@@ -150,8 +150,8 @@ class Test(helper_io.NoOutputAutoTimeControlledInputTestCase):
 
     def test_kernel_run_dumps_state_with_capital_d_input(self):
 
-        def task():
-            yield ('sleep', 1)
+        async def task():
+            await api.sleep(1)
 
         log_handler = helper_log.create_and_add_handler()
         self.addCleanup(lambda: helper_log.remove_handler(log_handler))

--- a/tests/kernel/test_task_api_key.py
+++ b/tests/kernel/test_task_api_key.py
@@ -5,8 +5,7 @@
 # See LICENSE for details.
 # ----------------------------------------------------------------------------
 
-from ppytty import run
-from ppytty.kernel import scheduler
+from ppytty.kernel import run, scheduler
 
 from . import helper_io
 from . import helper_log

--- a/tests/kernel/test_task_api_msgs.py
+++ b/tests/kernel/test_task_api_msgs.py
@@ -5,7 +5,8 @@
 # See LICENSE for details.
 # ----------------------------------------------------------------------------
 
-from ppytty import run, TrapException
+from ppytty.kernel import run
+from ppytty.kernel.exceptions import TrapException
 
 from . import helper_io
 

--- a/tests/kernel/test_task_api_msgs.py
+++ b/tests/kernel/test_task_api_msgs.py
@@ -5,7 +5,7 @@
 # See LICENSE for details.
 # ----------------------------------------------------------------------------
 
-from ppytty.kernel import run
+from ppytty.kernel import run, api
 from ppytty.kernel.exceptions import TrapException
 
 from . import helper_io
@@ -14,18 +14,18 @@ from . import helper_io
 
 class TestParentToChild(helper_io.NoOutputTestCase):
 
-    def _child(self, sleep_first):
+    async def _child(self, sleep_first):
         if sleep_first:
-            yield ('sleep', 0)
-        sender, message = yield ('message-wait',)
+            await api.sleep(0)
+        sender, message = await api.message_wait()
         return ('child tag', sender, message)
 
 
-    def _parent(self, child_sleeps_first):
+    async def _parent(self, child_sleeps_first):
         child_task = self._child(child_sleeps_first)
-        yield ('task-spawn', child_task)
-        yield ('message-send', child_task, 'ping?')
-        completed_task, child_success, child_result = yield ('task-wait',)
+        await api.task_spawn(child_task)
+        await api.message_send(child_task, 'ping?')
+        completed_task, child_success, child_result = await api.task_wait()
         return completed_task is child_task, child_success, child_result
 
 
@@ -66,18 +66,18 @@ class TestParentToChild(helper_io.NoOutputTestCase):
 
 class TestChildToParent(helper_io.NoOutputTestCase):
 
-    def _child(self, sleep_first):
+    async def _child(self, sleep_first):
         if sleep_first:
-            yield ('sleep', 0)
-        yield ('message-send', None, 'child-to-parent-message')
+            await api.sleep(0)
+        await api.message_send(None, 'child-to-parent-message')
         return 'child-return-value'
 
 
-    def _parent(self, child_sleeps_first):
+    async def _parent(self, child_sleeps_first):
         child_task = self._child(child_sleeps_first)
-        yield ('task-spawn', child_task)
-        sender_task, message = yield ('message-wait',)
-        completed_task, child_success, child_result = yield ('task-wait',)
+        await api.task_spawn(child_task)
+        sender_task, message = await api.message_wait()
+        completed_task, child_success, child_result = await api.task_wait()
         return {
             'sender-task-correct': sender_task is child_task,
             'received-message': message,
@@ -122,22 +122,22 @@ class TestChildToParent(helper_io.NoOutputTestCase):
 
 class TestSenderTaskIsChildTask(helper_io.NoOutputTestCase):
 
-    def _fast_child(self):
+    async def _fast_child(self):
 
-        yield ('message-send', None, 'hi-from-child')
-
-
-    def _slow_child(self):
-
-        yield ('sleep', 0)
-        yield ('message-send', None, 'hi-from-child')
+        await api.message_send(None, 'hi-from-child')
 
 
-    def _parent(self, child_object):
+    async def _slow_child(self):
 
-        yield ('task-spawn', child_object)
-        sender_task, message = yield ('message-wait',)
-        completed_child, child_success, child_result = yield ('task-wait',)
+        await api.sleep(0)
+        await api.message_send(None, 'hi-from-child')
+
+
+    async def _parent(self, child_object):
+
+        await api.task_spawn(child_object)
+        sender_task, message = await api.message_wait()
+        completed_child, child_success, child_result = await api.task_wait()
         return sender_task, message, completed_child, child_success, child_result
 
 
@@ -192,8 +192,8 @@ class TestTrapExceptions(helper_io.NoOutputTestCase):
 
     def test_top_task_message_parent_fails(self):
 
-        def top_task():
-            yield ('message-send', None, 'goes-nowhere')
+        async def top_task():
+            await api.message_send(None, 'goes-nowhere')
 
         success, result = run(top_task)
 

--- a/tests/kernel/test_task_api_sleep.py
+++ b/tests/kernel/test_task_api_sleep.py
@@ -7,7 +7,7 @@
 
 import itertools as it
 
-from ppytty.kernel import run, hw
+from ppytty.kernel import run, api
 
 from . import helper_io
 
@@ -15,9 +15,9 @@ from . import helper_io
 
 class TestSleep(helper_io.NoOutputAutoTimeTestCase):
 
-    def _sleeper(self, sleep_time):
+    async def _sleeper(self, sleep_time):
 
-        yield ('sleep', sleep_time)
+        await api.sleep(sleep_time)
 
 
     def test_sleep(self):
@@ -30,12 +30,12 @@ class TestSleep(helper_io.NoOutputAutoTimeTestCase):
                 self.assertIsNone(result)
 
 
-    def _spawn_sleepers(self, sleeper1, sleeper2):
+    async def _spawn_sleepers(self, sleeper1, sleeper2):
 
-        yield ('task-spawn', sleeper1)
-        yield ('task-spawn', sleeper2)
-        completed_1st, _, _ = yield ('task-wait',)
-        completed_2nd, _, _ = yield ('task-wait',)
+        await api.task_spawn(sleeper1)
+        await api.task_spawn(sleeper2)
+        completed_1st, _, _ = await api.task_wait()
+        completed_2nd, _, _ = await api.task_wait()
         return completed_1st, completed_2nd
 
 

--- a/tests/kernel/test_task_api_state.py
+++ b/tests/kernel/test_task_api_state.py
@@ -7,7 +7,8 @@
 
 import unittest
 
-from ppytty import run, TrapException
+from ppytty.kernel import run
+from ppytty.kernel.exceptions import TrapException
 
 from . import helper_io
 from . import helper_log

--- a/tests/kernel/test_task_api_state.py
+++ b/tests/kernel/test_task_api_state.py
@@ -7,7 +7,7 @@
 
 import unittest
 
-from ppytty.kernel import run
+from ppytty.kernel import run, api
 from ppytty.kernel.exceptions import TrapException
 
 from . import helper_io
@@ -38,8 +38,8 @@ class TestNeedingOutput(unittest.TestCase):
 
     def test_state_dump_logs_all_state_fields(self):
 
-        def task():
-            yield ('state-dump',)
+        async def task():
+            await api.state_dump()
 
         success, result = run(task)
 
@@ -72,8 +72,8 @@ class Test(helper_io.NoOutputAutoTimeTestCase):
 
     def _assert_state_dump_logs_top_task(self, runnable=False):
 
-        def task():
-            yield('state-dump',)
+        async def task():
+            await api.state_dump()
 
         user_level_task = task() if runnable else task
         success, result = run(user_level_task)
@@ -104,43 +104,43 @@ class Test(helper_io.NoOutputAutoTimeTestCase):
 
     def test_state_dump_logs_correct_task_states(self):
 
-        def sleeping():
-            yield ('sleep', 42)
+        async def sleeping():
+            await api.sleep(42)
 
-        def wait_child():
-            yield ('task-spawn', sleeping)
-            yield ('task-wait',)
+        async def wait_child():
+            await api.task_spawn(sleeping)
+            await api.task_wait()
 
-        def wait_inbox():
-            yield ('message-wait',)
+        async def wait_inbox():
+            await api.message_wait()
 
-        def wait_key():
-            yield ('read-key', 1000)
+        async def wait_key():
+            await api.key_read(1000)
 
-        def completed():
-            yield ('sleep', 0)
+        async def completed():
+            await api.sleep(0)
 
-        def runnable():
-            yield ('sleep', 0)
+        async def runnable():
+            await api.sleep(0)
 
-        def parent():
+        async def parent():
             # Nuance: `runnable` spawned last means it will still be in the
             # runnable state when the `state-dump` trap is called.
             all_tasks = (wait_child, wait_inbox, wait_key, completed, runnable)
             for task in all_tasks:
-                yield ('task-spawn', task)
+                await api.task_spawn(task)
 
-            yield ('state-dump',)
+            await api.state_dump()
 
             for task in all_tasks:
                 try:
-                    yield ('task-destroy', task)
+                    await api.task_destroy(task)
                 except TrapException:
                     # the `completed` task triggers this: it was waited by one
                     # of the previous `task-waits` and it no longer exists.
                     pass
                 finally:
-                    yield ('task-wait',)
+                    await api.task_wait()
 
         success, result = run(parent)
 

--- a/tests/kernel/test_task_api_tasks.py
+++ b/tests/kernel/test_task_api_tasks.py
@@ -7,8 +7,9 @@
 
 import unittest
 
-from ppytty import (
-    run, TrapException, TrapDoesNotExist, TrapArgCountWrong, TrapDestroyed,
+from ppytty.kernel import run
+from ppytty.kernel.exceptions import (
+    TrapException, TrapDoesNotExist, TrapArgCountWrong, TrapDestroyed,
 )
 
 from . import helper_io

--- a/tests/kernel/test_task_api_windows.py
+++ b/tests/kernel/test_task_api_windows.py
@@ -5,8 +5,8 @@
 # See LICENSE for details.
 # ----------------------------------------------------------------------------
 
-from ppytty import run, TrapException
-from ppytty.kernel import window
+from ppytty.kernel import run, window
+from ppytty.kernel.exceptions import TrapException
 from ppytty.kernel.state import state
 
 from . import helper_io

--- a/tests/kernel/test_task_api_windows.py
+++ b/tests/kernel/test_task_api_windows.py
@@ -5,7 +5,7 @@
 # See LICENSE for details.
 # ----------------------------------------------------------------------------
 
-from ppytty.kernel import run, window
+from ppytty.kernel import run, api, window
 from ppytty.kernel.exceptions import TrapException
 from ppytty.kernel.state import state
 
@@ -17,8 +17,8 @@ class Test(helper_io.NoOutputTestCase):
 
     def test_window_create_returns_a_window(self):
 
-        def task():
-            w = yield ('window-create', 0, 0, 40, 20)
+        async def task():
+            w = await api.window_create(0, 0, 40, 20)
             is_window_instance = isinstance(w, window.Window)
             return is_window_instance
 
@@ -29,9 +29,9 @@ class Test(helper_io.NoOutputTestCase):
 
     def test_window_destroy_raises_with_bad_argument(self):
 
-        def task():
+        async def task():
             non_window_object = 42
-            yield ('window-destroy', non_window_object)
+            await api.window_destroy(non_window_object)
 
         success, result = run(task)
         self.assertFalse(success)
@@ -42,9 +42,9 @@ class Test(helper_io.NoOutputTestCase):
 
     def test_window_create_and_destroy(self):
 
-        def task():
-            w = yield ('window-create', 0, 0, 40, 20)
-            yield ('window-destroy', w)
+        async def task():
+            w = await api.window_create(0, 0, 40, 20)
+            await api.window_destroy(w)
 
         success, result = run(task)
         self.assertTrue(success)
@@ -53,14 +53,14 @@ class Test(helper_io.NoOutputTestCase):
 
     def test_task_windows_destroyed_on_task_completion(self):
 
-        def child():
-            w = yield ('window-create', 0, 0, 40, 20)
+        async def child():
+            w = await api.window_create(0, 0, 40, 20)
             window_in_state = w in state.all_windows
             return window_in_state
 
-        def parent():
-            yield ('task-spawn', child)
-            _, child_success, window_in_state = yield ('task-wait',)
+        async def parent():
+            await api.task_spawn(child)
+            _, child_success, window_in_state = await api.task_wait()
             window_cleared = len(state.all_windows) == 0
             return child_success, window_in_state, window_cleared
 
@@ -75,14 +75,14 @@ class Test(helper_io.NoOutputTestCase):
 
     def test_task_windows_destroyed_on_task_exception(self):
 
-        def child():
-            w = yield ('window-create', 0, 0, 40, 20)
+        async def child():
+            w = await api.window_create(0, 0, 40, 20)
             window_in_state = w in state.all_windows
             raise RuntimeError(window_in_state)
 
-        def parent():
-            yield ('task-spawn', child)
-            _, child_success, child_exception = yield ('task-wait',)
+        async def parent():
+            await api.task_spawn(child)
+            _, child_success, child_exception = await api.task_wait()
             window_cleared = len(state.all_windows) == 0
             return child_success, child_exception, window_cleared
 
@@ -99,9 +99,9 @@ class Test(helper_io.NoOutputTestCase):
 
     def test_window_render_raises_with_bad_argument(self):
 
-        def task():
+        async def task():
             non_window_object = 42
-            yield ('window-render', non_window_object)
+            await api.window_render(non_window_object)
 
         success, result = run(task)
         self.assertFalse(success)
@@ -112,11 +112,11 @@ class Test(helper_io.NoOutputTestCase):
 
     def test_single_window_print_and_render(self):
 
-        def task():
-            w = yield ('window-create', 0, 0, 40, 20)
+        async def task():
+            w = await api.window_create(0, 0, 40, 20)
             w.print('text-in-the-window')
-            yield ('window-render', w)
-            yield ('window-destroy', w)
+            await api.window_render(w)
+            await api.window_destroy(w)
 
         success, result = run(task)
         self.assertTrue(success)
@@ -139,17 +139,17 @@ class Test(helper_io.NoOutputTestCase):
         #           |                       |
         #           +-----------------------+
 
-        def task():
+        async def task():
             # created first to exercise rendering optimizations
-            oth_win = yield ('window-create', 50, 3, 20, 5)
+            oth_win = await api.window_create(50, 3, 20, 5)
             oth_win.print('oth-win-frst-line', 0, 0)
             oth_win.print('oth-win-last-line', 0, 4)
 
-            bot_win = yield ('window-create', 10, 5, 30, 10)
+            bot_win = await api.window_create(10, 5, 30, 10)
             bot_win.print('bot-win-frst-line', 0, 0)
             bot_win.print('bot-win-last-line', 0, 9)
 
-            top_win = yield ('window-create', 0, 0, 30, 10)
+            top_win = await api.window_create(0, 0, 30, 10)
             top_win.print('top-win-frst-line', 0, 0)
             top_win.print('top-win-last-line', 0, 9)
 
@@ -158,7 +158,7 @@ class Test(helper_io.NoOutputTestCase):
                 return False, 'top_win/bot_win do not overlap'
 
             # rendering bot_win forces the overlapped top_win to render as well
-            yield ('window-render', bot_win)
+            await api.window_render(bot_win)
 
             # rendering pseudo-assertions
             written_bytes = self.get_os_written_bytes()
@@ -180,7 +180,7 @@ class Test(helper_io.NoOutputTestCase):
 
             # rendering oth_win should not re-render the other windows:
             # even though they are on top, they do not overlap
-            yield ('window-render', oth_win)
+            await api.window_render(oth_win)
 
             # rendering pseudo-assertions
             written_bytes = self.get_os_written_bytes()
@@ -203,27 +203,27 @@ class Test(helper_io.NoOutputTestCase):
 
     def test_task_termination_forces_all_other_windows_render(self):
 
-        def child():
-            w = yield ('window-create', 40, 0, 30, 10)
-            yield ('window-render', w)
-            yield ('message-send', None, 'child-rendered')
-            yield ('message-wait',)
+        async def child():
+            w = await api.window_create(40, 0, 30, 10)
+            await api.window_render(w)
+            await api.message_send(None, 'child-rendered')
+            await api.message_wait()
 
-        def parent():
+        async def parent():
             # setup our window
-            w = yield ('window-create', 0, 0, 30, 10)
+            w = await api.window_create(0, 0, 30, 10)
             w.print('parent-window-frst-line', 0, 0)
             w.print('parent-window-last-line', 0, 9)
-            yield ('window-render', w)
+            await api.window_render(w)
 
             # child will create a window and let parent know when it's rendered
-            yield ('task-spawn', child)
-            yield ('message-wait',)
+            await api.task_spawn(child)
+            await api.message_wait()
 
             # reset os written bytes and send message so that child terminates
             self.reset_os_written_bytes()
-            yield ('message-send', child, 'you-can-terminate')
-            yield ('task-wait',)
+            await api.message_send(child, 'you-can-terminate')
+            await api.task_wait()
 
             # caller will assert that os written bytes include our window
             return self.get_os_written_bytes()


### PR DESCRIPTION
Highlights:
* Addresses #4.
* Supports yield based trap calls: `yield ('sleep', 42)`...
* ...and coroutine based calls: `await sleep(42)`.
* All tests updated to the new API...
* ...except the yield-based ones exercising invalid trap calls.