### PR TITLE
Log warnings when processes are not waited.

### DIFF
--- a/src/ppytty/kernel/loop.py
+++ b/src/ppytty/kernel/loop.py
@@ -250,6 +250,8 @@ def process_task_completion(task, success, result):
     state.clear_task_parenthood(task)
     state.clear_trap_info(task)
     common.destroy_task_windows(task)
+    if task in state.task_processes:
+        log.warning('%r did not wait for spawned processes: %r', task, state.task_processes[task])
 
 
 

--- a/src/ppytty/kernel/traps.py
+++ b/src/ppytty/kernel/traps.py
@@ -300,6 +300,8 @@ def task_destroy(task, user_child_task, keep_running=True):
         state.cleanup_tasks_waiting_time_hq()
     elif child_task in state.tasks_waiting_inbox:
         state.tasks_waiting_inbox.remove(child_task)
+    elif child_task in state.tasks_waiting_processes:
+        state.tasks_waiting_processes.remove(child_task)
     elif child_task in state.completed_tasks:
         del state.completed_tasks[child_task]
     else:
@@ -309,6 +311,9 @@ def task_destroy(task, user_child_task, keep_running=True):
 
     state.clear_trap_info(child_task)
     common.destroy_task_windows(child_task)
+    if child_task in state.task_processes:
+        log.warning('%r did not wait for spawned processes: %r',
+                    child_task, state.task_processes[child_task])
     if keep_running:
         state.completed_tasks[child_task]  = (False, exceptions.TrapDestroyed(task))
         state.runnable_tasks.append(task)

--- a/tests/kernel/helper_log.py
+++ b/tests/kernel/helper_log.py
@@ -19,7 +19,7 @@ class Handler(logging.Handler):
 
     def emit(self, record):
 
-        self.messages.append(self.format(record))
+        self.messages.append((record.levelname, self.format(record)))
 
 
 

--- a/tests/kernel/helper_state.py
+++ b/tests/kernel/helper_state.py
@@ -122,6 +122,7 @@ class StateAssertionsMixin(object):
         'tasks_waiting_inbox',
         'tasks_waiting_key',
         'tasks_waiting_time',
+        'tasks_waiting_processes',
     )
     def assert_no_tasks(self):
 

--- a/tests/kernel/test_task_api_key.py
+++ b/tests/kernel/test_task_api_key.py
@@ -130,8 +130,8 @@ class Test(helper_io.NoOutputAutoTimeControlledInputTestCase):
         self.assertIsNone(result)
 
         separator_line_count = sum(
-            1 for msg in log_handler.messages
-            if 'DUMP STATE' in msg
+            1 for level, msg in log_handler.messages
+            if 'DUMP STATE' in msg and level=='CRITICAL'
         )
         self.assertGreaterEqual(separator_line_count, 1)
 

--- a/tests/kernel/test_task_api_procs.py
+++ b/tests/kernel/test_task_api_procs.py
@@ -5,6 +5,7 @@
 # See LICENSE for details.
 # ----------------------------------------------------------------------------
 
+import os
 import textwrap
 import signal
 import sys
@@ -12,26 +13,27 @@ import sys
 from ppytty.kernel import run, api
 
 from . import helper_io
+from . import helper_log
+
+
+
+def _sleeper_process_args(seconds):
+
+    python_source_code = textwrap.dedent(f"""
+        import time, sys
+        time.sleep({seconds})
+        sys.exit(42)
+    """).strip()
+    return [sys.executable, '-c', python_source_code]
 
 
 
 class Tests(helper_io.NoOutputTestCase):
 
-    @staticmethod
-    def _sleeper_process_args(seconds):
-
-        python_source_code = textwrap.dedent(f"""
-            import time, sys
-            time.sleep({seconds})
-            sys.exit(42)
-        """).strip()
-        return [sys.executable, '-c', python_source_code]
-
-
     async def _spawn_sleep_wait(self, sleep_before_wait, process_sleep):
 
         window = await api.window_create(0, 0, 80, 25)
-        args = self._sleeper_process_args(process_sleep)
+        args = _sleeper_process_args(process_sleep)
         spawned_process = await api.process_spawn(window, args)
         await api.sleep(sleep_before_wait)
         completed_process = await api.process_wait()
@@ -68,7 +70,7 @@ class Tests(helper_io.NoOutputTestCase):
     async def _signal_test_task(self, send_signal_callable):
 
         window = await api.window_create(0, 0, 80, 25)
-        args = self._sleeper_process_args(42)
+        args = _sleeper_process_args(42)
         spawned_process = await api.process_spawn(window, args)
         # TODO: Something not 100% clear going on here.
         # Tests running this task fail "randomly". This sleep seems to help.
@@ -112,9 +114,60 @@ class Tests(helper_io.NoOutputTestCase):
 
 class TestOddCases(helper_io.NoOutputTestCase):
 
-    def test_spawn_process_and_terminate_task(self):
+    def setUp(self):
 
-        raise NotImplementedError()
+        super().setUp()
+        self.log_handler = helper_log.create_and_add_handler()
+
+
+    def tearDown(self):
+
+        helper_log.remove_handler(self.log_handler)
+        super().tearDown()
+
+
+    def test_spawn_dont_wait(self):
+
+        async def spawn_and_exit():
+            window = await api.window_create(0, 0, 80, 25)
+            args = _sleeper_process_args(42)
+            process = await api.process_spawn(window, args)
+            return process
+
+        # Calling it ourselves such that repr(task) can be found in the log.
+        task = spawn_and_exit()
+        success, process = run(task)
+
+        # Child process should have been left running, clean it up when done.
+        self.addCleanup(lambda: process.terminate())
+
+        # Task should have succeeded.
+        self.assertTrue(success, f'non-success result: {process!r}')
+
+        # Use an actual system call to confirm that the process is running.
+        still_running = None
+        try:
+            os.kill(process.pid, 0)
+        except OSError:
+            still_running = False
+        else:
+            still_running = True
+        finally:
+            self.assertTrue(still_running, 'expected process to be running')
+
+        # Since the process is running, these must be None
+        self.assertIsNone(process.exit_code, 'non-Non process.exit_code')
+        self.assertIsNone(process.exit_signal, 'non-Non process.exit_signal')
+
+        # A message should have been logged containing the following parts:
+        expected_parts = (repr(task), 'spawn', 'process', repr(process))
+        message_found = False
+        log_msgs = self.log_handler.messages
+        for msg in log_msgs:
+            if all(p in msg for p in expected_parts):
+                message_found = True
+                break
+        self.assertTrue(message_found, f'expected message not logged: {log_msgs}')
 
 
     def test_child_task_spawns_and_is_destroyed(self):

--- a/tests/kernel/test_task_api_procs.py
+++ b/tests/kernel/test_task_api_procs.py
@@ -163,8 +163,8 @@ class TestOddCases(helper_io.NoOutputTestCase):
         expected_parts = (repr(task), 'spawn', 'process', repr(process))
         message_found = False
         log_msgs = self.log_handler.messages
-        for msg in log_msgs:
-            if all(p in msg for p in expected_parts):
+        for level, msg in log_msgs:
+            if all(p in msg for p in expected_parts) and level=='WARNING':
                 message_found = True
                 break
         self.assertTrue(message_found, f'expected message not logged: {log_msgs}')

--- a/tests/kernel/test_task_api_state.py
+++ b/tests/kernel/test_task_api_state.py
@@ -39,8 +39,8 @@ class TestNeedingOutput(helper_io.NoOutputTestCase):
         for state_attr in helper_state.STATE_ATTRS:
             with self.subTest(state_attr=state_attr):
                 expected_pattern = f'state.{state_attr}='
-                for message in self.log_handler.messages:
-                    if expected_pattern in message:
+                for level, message in self.log_handler.messages:
+                    if expected_pattern in message and level=='CRITICAL':
                         break
                 else:
                     raise AssertionError(f'{expected_pattern!r} not found')
@@ -72,8 +72,8 @@ class Test(helper_io.NoOutputAutoTimeTestCase):
         self.assertIsNone(result)
 
         expected = str(user_level_task)
-        for message in self.log_handler.messages:
-            if expected in message:
+        for level, message in self.log_handler.messages:
+            if expected in message and level=='CRITICAL':
                 break
             if 'DATA STRUCTURES' in message:
                 # if we get to this point, the task hierarchy is gone
@@ -148,9 +148,9 @@ class Test(helper_io.NoOutputAutoTimeTestCase):
         }
         for task, expected_state in expected_states.items():
             with self.subTest(task=task, expected_state=expected_state):
-                task_str = str(task)
-                for message in self.log_handler.messages:
-                    if task_str in message and expected_state in message:
+                expected_parts = (str(task), expected_state)
+                for level, message in self.log_handler.messages:
+                    if all(p in message for p in expected_parts) and level=='CRITICAL':
                         break
                     if 'DATA STRUCTURES' in message:
                         # if we get to this point, the task hierarchy is gone


### PR DESCRIPTION
Also, do not hang when destroying tasks that are waiting for spawned process termination.