### PR TITLE
Terminal > Process input + Focus implemented

### DIFF
--- a/src/ppytty/kernel/common.py
+++ b/src/ppytty/kernel/common.py
@@ -22,6 +22,7 @@ def destroy_task_windows(task):
 
     for window in state.task_windows[task]:
         state.all_windows.remove(window)
+        state.cleanup_focusable_window_process(window)
     del state.task_windows[task]
 
     if need_rerender:

--- a/src/ppytty/kernel/state.py
+++ b/src/ppytty/kernel/state.py
@@ -239,7 +239,7 @@ class _State(object):
     def cleanup_focusable_window_process(self, window=None, process=None):
 
         if process is not None:
-            window = self.process_window[process]
+            window = self.process_window.get(process)
 
         if window not in self.focusable_windows:
             return

--- a/src/ppytty/kernel/traps.py
+++ b/src/ppytty/kernel/traps.py
@@ -127,6 +127,7 @@ def window_destroy(task, window):
 
     state.task_windows[task].remove(window)
     state.all_windows.remove(window)
+    state.cleanup_focusable_window_process(window)
 
     # One window is gone: need to re-render everything to account for it.
     # Possible optimizations:
@@ -381,6 +382,7 @@ def process_spawn(task, window, args, buffer_size=4096):
         exc = exceptions.TrapException('process spawning failed', e)
         state.trap_will_throw(task, exc)
     else:
+        state.track_focusable_window_process(window, process)
         state.track_task_process(task, process)
         state.track_input_fd(process.pty_master_fd, updater(process.pty_master_fd))
         state.trap_will_return(task, process)

--- a/tests/kernel/helper_state.py
+++ b/tests/kernel/helper_state.py
@@ -37,6 +37,19 @@ def _assert_empty_dict(object, attr_name):
         raise AssertionError(f'{attr_name!r} with non-zero length: {value!r}')
 
 
+def _assert_none_mapping_dict(object, attr_name):
+
+    value = getattr(object, attr_name)
+    for expected_attr in ('keys', 'values', 'items'):
+        if not hasattr(value, expected_attr):
+            raise AssertionError(f'{attr_name!r} not dict-like: no {expected_attr} method')
+    if len(value) != 1:
+        raise AssertionError(f'{attr_name!r} with non-1 length: {value!r}')
+    expect_none = value[None]
+    if expect_none is not None:
+        raise AssertionError(f'None not mapped to None')
+
+
 def _assert_empty_set(object, attr_name):
 
     value = getattr(object, attr_name)
@@ -100,6 +113,10 @@ STATE_ATTRS = {
     'task_inbox': (_assert_empty_dict, _change_dict),
     'task_windows': (_assert_empty_dict, _change_dict),
     'all_windows': (_assert_empty_list, _change_list),
+    'focusable_windows': (_assert_empty_list, _change_list),
+    'focused_window': (_assert_is_none, _change_scalar),
+    'process_window': (_assert_empty_dict, _change_dict),
+    'window_process': (_assert_none_mapping_dict, _change_dict),
     'task_processes': (_assert_empty_dict, _change_dict),
     'process_task': (_assert_empty_dict, _change_dict),
     'all_processes': (_assert_empty_dict, _change_dict),


### PR DESCRIPTION
Major progress towards completing #5:
* Process windows are focusable.
* CTRL-F changes focus: cycles between process windows and `None`.
* When a process window is focused, terminal input is written to the process PTY.

Pending:
* Need to review low-level I/O loop terminal input handling: currently preventing from sending `q` and `D` to process PTYs.
* Terminal cursor visibility: mostly not working.
  * Should not be visible when there are no focused process windows.
  * Should be visible on the focused process window, if visible in that context.
* Somehow visually indicate focus changes such that users know which window/process is focused.