### PR TITLE
Revised low-level terminal input: no longer consumes particular inputs.

### DIFF
--- a/tests/kernel/test_python_api.py
+++ b/tests/kernel/test_python_api.py
@@ -28,13 +28,13 @@ class TestRun(helper_io.NoOutputAutoTimeControlledInputTestCase):
         run(generator_object)
 
 
-    def test_run_with_prompt_needs_double_q_to_complete(self):
+    def test_run_with_prompt_needs_ctrl_f_dot_to_complete(self):
 
-        pre_callable = lambda: self.input_control.feed_data(b'qq!')
+        pre_callable = lambda: self.input_control.feed_data(b'\x06.!')
 
         run(tasks.sleep_zero(pre_callable), post_prompt='[COMPLETED]')
 
-        # Check first two b'q' in the input were consumed: buffer holds b'!'.
+        # Check first bytes in the input were consumed: buffer holds b'!'.
         self.assertTrue(len(self.input_control.buffer), 1)
         self.assertEqual(self.input_control.buffer[0], b'!')
 

--- a/tests/kernel/test_task_api_key.py
+++ b/tests/kernel/test_task_api_key.py
@@ -86,10 +86,10 @@ class Test(helper_io.NoOutputAutoTimeControlledInputTestCase):
         self.assertIs(destroyed_task, first_reader_child)
 
 
-    def test_kernel_run_stops_with_double_q_input(self):
+    def test_kernel_run_stops_with_ctrl_f_dot_input(self):
 
         async def task():
-            self.input_control.feed_data(b'qq')
+            self.input_control.feed_data(b'\x06.')
             while True:
                 await api.sleep(42)
 
@@ -99,13 +99,13 @@ class Test(helper_io.NoOutputAutoTimeControlledInputTestCase):
         self.assertIsInstance(result, loop._ForcedStop)
 
 
-    def test_kernel_run_does_not_stop_with_q_and_something_else(self):
+    def test_kernel_run_does_not_stop_with_ctrl_f_and_something_else(self):
 
         async def task():
             await api.sleep(42)
             return 'confirming-regular-completion'
 
-        self.input_control.feed_data(b'qx')
+        self.input_control.feed_data(b'\x06x')
 
         success, result = run(task)
 
@@ -114,7 +114,7 @@ class Test(helper_io.NoOutputAutoTimeControlledInputTestCase):
         self.assertEqual(result, 'confirming-regular-completion')
 
 
-    def test_kernel_run_dumps_state_with_capital_d_input(self):
+    def test_kernel_run_dumps_state_with_ctrl_f_d_input(self):
 
         async def task():
             await api.sleep(1)
@@ -122,7 +122,7 @@ class Test(helper_io.NoOutputAutoTimeControlledInputTestCase):
         log_handler = helper_log.create_and_add_handler()
         self.addCleanup(lambda: helper_log.remove_handler(log_handler))
 
-        self.input_control.feed_data(b'D')
+        self.input_control.feed_data(b'\x06d')
 
         success, result = run(task)
 


### PR DESCRIPTION
Addresses #105 in full.

Revamped:
* CTRL-F grabs the input.
* Once grabbed:
  * `.` quits.
  * `d` dumps state.
  * `f` changes process window focus.
  * CTRL-F is sent to the focused process PTY (or read-wait task, if any and focus is `None`)
  * Any other input is is discarded.
  * Automatically ungrabbed after first grabbed read.
