### PR TITLE
Fix for CTRL-C in Python REPL on Linux.

### DIFF
--- a/src/ppytty/kernel/process.py
+++ b/src/ppytty/kernel/process.py
@@ -47,12 +47,12 @@ class Process(object):
     def _set_stdin_as_controlling_terminal():
 
         try:
-            fcntl.fcntl(0, termios.TIOCSCTTY, 0)
-        except OSError:
-            # TODO: Figure out what's going on here.
-            # Failing on Linux with errno=22, but ok on macOS.
-            # PS: Can't log this failure: this runs in the child process.
-            pass
+            fcntl.ioctl(0, termios.TIOCSCTTY, 0)
+        except OSError as e:
+            # This runs in the spawned child process, we can't log errors.
+            # The best we can do is output them to the child's STDERR.
+            msg = f'Failed setting STDIN as controlling terminal: {e!r}'
+            os.write(2, msg.encode('ascii', errors='xmlcharrefreplace'))
 
     def __repr__(self):
 

--- a/src/ppytty/kernel/traps.py
+++ b/src/ppytty/kernel/traps.py
@@ -370,9 +370,13 @@ def process_spawn(task, window, args, buffer_size=4096):
     def updater(from_fd):
 
         def callback():
-            window.feed(os.read(from_fd, buffer_size))
-            common.render_window_to_terminal(window, full=False)
-            state.terminal.render()
+            data = os.read(from_fd, buffer_size)
+            if data:
+                window.feed(data)
+                common.render_window_to_terminal(window, full=False)
+                state.terminal.render()
+            # Let caller know whether we pushed data or from_fd is at EOF.
+            return data
 
         return callback
 


### PR DESCRIPTION
Addresses one test case in #110.