### PR TITLE
Fix cursor rendering when there is non other visible output.

### DIFF
--- a/src/ppytty/kernel/terminal.py
+++ b/src/ppytty/kernel/terminal.py
@@ -168,10 +168,10 @@ class Terminal(object):
         self._window_feed(data)
 
 
-    def render(self, full=False, cursor_only=False):
+    def render(self, full=False, cursor_only=False, do_cursor=False):
 
         data = self._window_render(full=full, encoding=self._encoding,
-                                   cursor_only=cursor_only)
+                                   cursor_only=cursor_only, do_cursor=do_cursor)
         self._os_write_out_fd(data)
 
 

--- a/src/ppytty/kernel/traps.py
+++ b/src/ppytty/kernel/traps.py
@@ -374,7 +374,9 @@ def process_spawn(task, window, args, buffer_size=4096):
             if data:
                 window.feed(data)
                 common.render_window_to_terminal(window, full=False)
-                state.terminal.render()
+                # Cursor moves with no other visible output must be rendered.
+                common.update_terminal_cursor_from_focus()
+                state.terminal.render(do_cursor=True)
             # Let caller know whether we pushed data or from_fd is at EOF.
             return data
 

--- a/src/ppytty/kernel/window.py
+++ b/src/ppytty/kernel/window.py
@@ -338,7 +338,11 @@ class Window(object):
         self._stream.feed(data)
 
 
-    def render(self, full=False, encoding='utf8', cursor_only=False):
+    def render(self, full=False, encoding='utf8', cursor_only=False, do_cursor=False):
+
+        # full: if True, renders all lines; otherwise, renders changed lines.
+        # cursor_only: if True, renders no lines, but renders the cursor.
+        # do_cursor: if True, cursor is rendered with or without rendered lines.
 
         self_parent = self._parent
         screen = self._screen
@@ -371,7 +375,7 @@ class Window(object):
                     if -top <= line_no < self_parent.height - top
                 }
 
-        if line_numbers or cursor_only:
+        if line_numbers or cursor_only or do_cursor:
             payload_append(bt.hide_cursor)
 
         # Do not render columns outside of parent geometry
@@ -394,7 +398,7 @@ class Window(object):
                     prev_char_format = char_format
                 payload_append(char_data)
 
-        if line_numbers or cursor_only:
+        if line_numbers or cursor_only or do_cursor:
             payload_append(bt.normal)
             # TODO: Improve cursor handling if outside parent geometry.
             payload_append(bt_move(max(0, top+screen_cursor.y), render_left+screen_cursor.x))


### PR DESCRIPTION
Addresses cursor movement failing tests in #110.