### PR TITLE
Inter-Widget messaging fixes.

### DIFF
--- a/src/ppytty/lib/slide.py
+++ b/src/ppytty/lib/slide.py
@@ -186,33 +186,45 @@ class Slide(widget.WindowWidget):
             except ValueError:
                 self._log.warning('%r: invalid %r launch time request: %r', self, requester_widget, request)
                 continue
-            if action == 'launch':
-                last_widget_index = len(action_args)-1
-                for i, widget_to_launch in enumerate(action_args):
-                    if isinstance(widget_to_launch, widget.WindowWidget):
-                        self._template_slot_index += 1
-                    context['geometry'] = self._template_geometry(self._template_slot_index)
-                    terminal_render = (last_widget_index == i)
-                    await self.launch_widget(widget=widget_to_launch, till_done=True,
-                                             terminal_render=terminal_render, **context)
-            elif action == 'cleanup':
-                widgets_to_cleanup, window_destroy_args = action_args
-                for widget_to_cleanup in widgets_to_cleanup:
-                    if widget_to_cleanup not in self._launched_widgets:
-                        self._log.warning('%r: cannot cleanup unlaunched widget %r', self, widget_to_cleanup)
-                        continue
-                    self._launched_widgets.remove(widget_to_cleanup)
-                    await widget_to_cleanup.cleanup(**window_destroy_args)
-            elif action == 'message':
-                destination, message = action_args
-                await api.message_send(destination, message)
-                responder, response = await api.message_wait()
-                if responder is not destination:
-                    self._log.warning('%r: unexpected responder=%r, response=%r', self, responder, response)
+            launchtime_handler_name = f'handle_launchtime_{action}'
+            try:
+                launchtime_handler = getattr(self, launchtime_handler_name)
+            except AttributeError:
+                self._log.warning('%r: unhandled %r launch time action: %r', self, requester_widget, action)
             else:
-                self._log.warning('%r: invalid %r launch time action: %r', self, requester_widget, action)
+                await launchtime_handler(*action_args, **context)
 
         del self._widget_launchtime_requests[requester_widget]
+
+
+    async def handle_launchtime_launch(self, *widgets_to_launch, **context):
+
+        last_widget_index = len(widgets_to_launch)-1
+        for i, widget_to_launch in enumerate(widgets_to_launch):
+            if isinstance(widget_to_launch, widget.WindowWidget):
+                self._template_slot_index += 1
+            context['geometry'] = self._template_geometry(self._template_slot_index)
+            terminal_render = (last_widget_index == i)
+            await self.launch_widget(widget=widget_to_launch, till_done=True,
+                                        terminal_render=terminal_render, **context)
+
+
+    async def handle_launchtime_cleanup(self, widgets_to_cleanup, window_destroy_args, **_context):
+
+        for widget_to_cleanup in widgets_to_cleanup:
+            if widget_to_cleanup not in self._launched_widgets:
+                self._log.warning('%r: cannot cleanup unlaunched widget %r', self, widget_to_cleanup)
+                continue
+            self._launched_widgets.remove(widget_to_cleanup)
+            await widget_to_cleanup.cleanup(**window_destroy_args)
+
+
+    async def handle_launchtime_message(self, destination, message, **context):
+
+        await api.message_send(destination, message)
+        responder, response = await api.message_wait()
+        if responder is not destination:
+            self._log.warning('%r: unexpected responder=%r, response=%r', self, responder, response)
 
 
     async def handle_cleanup(self, **_kwargs):

--- a/src/ppytty/lib/thing.py
+++ b/src/ppytty/lib/thing.py
@@ -32,7 +32,14 @@ class Thing(task.Task):
         self._initial_state = initial_state
         self._state = self._initial_state
 
+        self._last_sender = None
         self._done = False
+
+
+    @property
+    def controller(self):
+
+        return self._last_sender
 
 
     def reset(self):
@@ -47,7 +54,7 @@ class Thing(task.Task):
         self._log.info('%r: started', self)
 
         while not self._done:
-            sender, message = await api.message_wait()
+            self._last_sender, message = await api.message_wait()
             self._log.debug('%s: got message: %r', self, message)
             request, request_args = message
             handler = self.get_handler(request)
@@ -57,7 +64,7 @@ class Thing(task.Task):
                 self._log.error('handler exception', exc_info=True)
             else:
                 self._state = new_state
-            await api.message_send(sender, new_state)
+            await api.message_send(self._last_sender, new_state)
 
         self._log.info('%r: done', self)
 

--- a/src/ppytty/lib/widget.py
+++ b/src/ppytty/lib/widget.py
@@ -210,13 +210,12 @@ class WidgetsCleaner(Widget):
     """
     WidgetsCleaner class.
 
-    Once 'next'ed asks the parent to cleanup its wrapped/referenced widgets and
-    becomes 'done'.
+    Once 'next'ed asks the controller task to cleanup its wrapped/referenced
+    widgets and becomes 'done'.
     """
 
-    # Only the parent (or, more precisely, only whoever launched the Widgets)
-    # can properly clean them up. Motive: Widgets are Tasks, their termination
-    # must be waited on by whomever spawned them.
+    # Only the whoever launched the Widgets can properly clean them up: Widgets
+    # are Tasks, their termination must be waited on by their parent.
 
     def __init__(self, *widgets):
 
@@ -238,12 +237,12 @@ class WidgetsCleaner(Widget):
 
         await super().handle_idle_next()
 
-        self._log.info('%r: asking parent to cleanup %r', self, self._widgets)
+        self._log.info('%r: asking controller to cleanup %r', self, self._widgets)
         window_destroy_args = dict(
             terminal_render=terminal_render,
             clear_buffer=clear_buffer,
         )
-        await api.message_send(None, ('cleanup', (self._widgets, window_destroy_args)))
+        await api.message_send(self.controller, ('cleanup', (self._widgets, window_destroy_args)))
 
         return 'done'
 
@@ -254,8 +253,8 @@ class WidgetsLauncher(Widget):
     """
     WidgetsLauncher class.
 
-    Once 'next'ed asks the parent to launch its wrapped/referenced widgets and
-    becomes 'done'.
+    Once 'next'ed asks the controller task to launch its wrapped/referenced
+    widgets and becomes 'done'.
     """
 
     def __init__(self, *widgets):
@@ -277,8 +276,8 @@ class WidgetsLauncher(Widget):
 
         await super().handle_idle_next()
 
-        self._log.info('%r: asking parent to launch %r', self, self._widgets)
-        await api.message_send(None, ('launch', self._widgets))
+        self._log.info('%r: asking controller to launch %r', self, self._widgets)
+        await api.message_send(self.controller, ('launch', self._widgets))
 
         return 'done'
 
@@ -289,8 +288,8 @@ class WidgetRequester(Widget):
     """
     WidgetRequester class.
 
-    Once 'next'ed asks the parent to cleanup its wrapped/referenced widgets and
-    becomes 'done'.
+    Once 'next'ed asks the controller task to cleanup its wrapped/referenced
+    widgets and becomes 'done'.
     """
 
     def __init__(self, widget, request, **request_args):
@@ -313,8 +312,8 @@ class WidgetRequester(Widget):
 
         await super().handle_idle_next()
 
-        self._log.info('%r: asking parent to request %r from %r', self, self._message, self._widget)
-        await api.message_send(None, ('message', (self._widget, self._message)))
+        self._log.info('%r: asking controller to request %r from %r', self, self._message, self._widget)
+        await api.message_send(self.controller, ('message', (self._widget, self._message)))
 
         return 'done'
 


### PR DESCRIPTION
Notes:
* Things run a core message wait/send loop that is fundamental to their operation.
* Any other messaging done in the "handlers" can interfere with that core loop.
* The correct way to message send/wait at the "handler" level is to spawn sub-tasks.
* This PR does precisely that on two general cases:
  * In the `launch`, `forward` and `cleanup` Widget helper methods.
  * In the implementation of `WidgetRequest` in the context of Slides.

Fixes #167.